### PR TITLE
Wrap some config defines with #ifdef for easier user modification

### DIFF
--- a/lib_icer/inc/icer.h
+++ b/lib_icer/inc/icer.h
@@ -26,10 +26,18 @@ uint32_t __inline __clz( uint32_t value ) {
 
 #define ICER_CIRC_BUF_SIZE 2048
 #define MAX_K 12
+#ifndef ICER_MAX_SEGMENTS
 #define ICER_MAX_SEGMENTS 32
+#endif
+#ifndef ICER_MAX_DECOMP_STAGES
 #define ICER_MAX_DECOMP_STAGES 6
+#endif
+#ifndef ICER_MAX_PACKETS
 #define ICER_MAX_PACKETS 300
+#endif
+#ifndef ICER_MAX_PACKETS_16
 #define ICER_MAX_PACKETS_16 800
+#endif
 #define ICER_BITPLANES_TO_COMPRESS_8 7
 #define ICER_BITPLANES_TO_COMPRESS_16 9
 


### PR DESCRIPTION
This allows easier user configuration of certain definitions, namely
* `ICER_MAX_SEGMENTS`
* `ICER_MAX_DECOMP_STAGES`
* `ICER_MAX_PACKETS`
* `ICER_MAX_PACKETS_16`

Wrapping these with `#ifndef` allows them to be overridden with `target_compile_definitions(...)` in your implementation project's `CMakeLists.txt`, for example:

```cmake
target_link_libraries(${PROJECT_NAME} icer)
...
target_compile_definitions(icer PRIVATE
  ICER_MAX_SEGMENTS=8
)
```

##### Note:
`#define`s in the relying project do not propagate to the library and hence would not have effect. These have to be defined in the scope of this library with `target_compile_definitions(...)`.