### PR TITLE
Fix compiling with only decode/encode support

### DIFF
--- a/lib_icer/src/icer_color.c
+++ b/lib_icer/src/icer_color.c
@@ -334,6 +334,7 @@ int icer_decompress_image_yuv_uint8(uint8_t *y_channel, uint8_t *u_channel, uint
 #endif
 
 #ifdef USE_UINT16_FUNCTIONS
+#ifdef USE_ENCODE_FUNCTIONS
 int icer_compress_image_yuv_uint16(uint16_t *y_channel, uint16_t *u_channel, uint16_t *v_channel, size_t image_w,
                                   size_t image_h, uint8_t stages, enum icer_filter_types filt,
                                   uint8_t segments, icer_output_data_buf_typedef *const output_data) {
@@ -522,7 +523,9 @@ int icer_compress_image_yuv_uint16(uint16_t *y_channel, uint16_t *u_channel, uin
 
     return res;
 }
+#endif
 
+#ifdef USE_DECODE_FUNCTIONS
 int icer_decompress_image_yuv_uint16(uint16_t * const y_channel, uint16_t * const u_channel, uint16_t * const v_channel, size_t *const image_w,
                                     size_t *const image_h, const size_t image_bufsize, const uint8_t *datastream,
                                     const size_t data_length, const uint8_t stages, const enum icer_filter_types filt,
@@ -650,4 +653,5 @@ int icer_decompress_image_yuv_uint16(uint16_t * const y_channel, uint16_t * cons
     icer_inverse_wavelet_transform_stages_uint16(v_channel, im_w, im_h, stages, filt);
     return ICER_RESULT_OK;
 }
+#endif
 #endif

--- a/lib_icer/src/icer_compress.c
+++ b/lib_icer/src/icer_compress.c
@@ -273,6 +273,7 @@ int icer_decompress_image_uint8(uint8_t * const image, size_t * const image_w, s
 #endif
 
 #ifdef USE_UINT16_FUNCTIONS
+#ifdef USE_ENCODE_FUNCTIONS
 int icer_compress_image_uint16(uint16_t * const image, size_t image_w, size_t image_h, uint8_t stages, enum icer_filter_types filt,
                               uint8_t segments, icer_output_data_buf_typedef * const output_data) {
     int res;
@@ -421,7 +422,9 @@ int icer_compress_image_uint16(uint16_t * const image, size_t image_w, size_t im
 
     return res;
 }
+#endif
 
+#ifdef USE_DECODE_FUNCTIONS
 int icer_decompress_image_uint16(uint16_t * const image, size_t * const image_w, size_t * const image_h, size_t image_bufsize, const uint8_t *datastream,
                                  size_t data_length, uint8_t stages, enum icer_filter_types filt, uint8_t segments) {
     int chan = 0;
@@ -529,6 +532,7 @@ int icer_decompress_image_uint16(uint16_t * const image, size_t * const image_w,
     icer_inverse_wavelet_transform_stages_uint16(image, im_w, im_h, stages, filt);
     return ICER_RESULT_OK;
 }
+#endif
 #endif
 
 int icer_find_packet_in_bytestream(icer_image_segment_typedef **seg, const uint8_t *datastream, size_t data_length, size_t * const offset) {

--- a/lib_icer/src/icer_context_modeller.c
+++ b/lib_icer/src/icer_context_modeller.c
@@ -308,6 +308,7 @@ int icer_decompress_bitplane_uint8(uint8_t * const data, size_t plane_w, size_t 
 #endif
 
 #ifdef USE_UINT16_FUNCTIONS
+#ifdef USE_ENCODE_FUNCTIONS
 int icer_compress_bitplane_uint16(const uint16_t *data, size_t plane_w, size_t plane_h, size_t rowstride,
                                   icer_context_model_typedef *context_model,
                                   icer_encoder_context_typedef *encoder_context,
@@ -454,7 +455,9 @@ int icer_compress_bitplane_uint16(const uint16_t *data, size_t plane_w, size_t p
     }
     return ICER_RESULT_OK;
 }
+#endif
 
+#ifdef USE_DECODE_FUNCTIONS
 int icer_decompress_bitplane_uint16(uint16_t * const data, size_t plane_w, size_t plane_h, size_t rowstride,
                                     icer_context_model_typedef *context_model,
                                     icer_decoder_context_typedef *decoder_context,
@@ -597,6 +600,7 @@ int icer_decompress_bitplane_uint16(uint16_t * const data, size_t plane_w, size_
     }
     return ICER_RESULT_OK;
 }
+#endif
 #endif
 
 

--- a/lib_icer/src/icer_wavelet.c
+++ b/lib_icer/src/icer_wavelet.c
@@ -53,6 +53,7 @@ int icer_inverse_wavelet_transform_stages_uint8(uint8_t * const image, size_t im
 #endif
 
 #ifdef USE_UINT16_FUNCTIONS
+#ifdef USE_ENCODE_FUNCTIONS
 int icer_wavelet_transform_stages_uint16(uint16_t * const image, size_t image_w, size_t image_h, uint8_t stages,
                                         enum icer_filter_types filt) {
     bool overflow = false;
@@ -74,7 +75,9 @@ int icer_wavelet_transform_stages_uint16(uint16_t * const image, size_t image_w,
 
     return overflow ? ICER_INTEGER_OVERFLOW : ICER_RESULT_OK;
 }
+#endif
 
+#ifdef USE_DECODE_FUNCTIONS
 int icer_inverse_wavelet_transform_stages_uint16(uint16_t * const image, size_t image_w, size_t image_h, uint8_t stages,
                                                 enum icer_filter_types filt) {
     bool overflow = false;
@@ -98,6 +101,7 @@ int icer_inverse_wavelet_transform_stages_uint16(uint16_t * const image, size_t 
     }
     return overflow ? ICER_INTEGER_OVERFLOW : ICER_RESULT_OK;
 }
+#endif
 #endif
 
 size_t icer_get_dim_n_low_stages(size_t dim, uint8_t stages) {
@@ -147,6 +151,7 @@ int icer_inverse_wavelet_transform_2d_uint8(uint8_t * const image, size_t image_
 #endif
 
 #ifdef USE_UINT16_FUNCTIONS
+#ifdef USE_ENCODE_FUNCTIONS
 int icer_wavelet_transform_2d_uint16(uint16_t * const image, size_t image_w, size_t image_h, size_t rowstride,
                                     enum icer_filter_types filt) {
     bool overflow = false;
@@ -164,7 +169,9 @@ int icer_wavelet_transform_2d_uint16(uint16_t * const image, size_t image_w, siz
 
     return overflow ? ICER_INTEGER_OVERFLOW : ICER_RESULT_OK;
 }
+#endif
 
+#ifdef USE_DECODE_FUNCTIONS
 int icer_inverse_wavelet_transform_2d_uint16(uint16_t * const image, size_t image_w, size_t image_h, size_t rowstride,
                                             enum icer_filter_types filt) {
     bool overflow = false;
@@ -182,6 +189,7 @@ int icer_inverse_wavelet_transform_2d_uint16(uint16_t * const image, size_t imag
 
     return overflow ? ICER_INTEGER_OVERFLOW : ICER_RESULT_OK;
 }
+#endif
 #endif
 
 #ifdef USE_UINT8_FUNCTIONS


### PR DESCRIPTION
Although support is provided for compiling with only encode/decode support thru the `USE_ENCODE_FUNCTIONS` and `USE_DECODE_FUNCTIONS` definitions respectively, some portions of the code are not properly wrapped with `#ifdef` conditions. This causes errors when only one of `USE_ENCODE_FUNCTIONS` or `USE_DECODE_FUNCTIONS` is defined as those functions rely on other functions that are correctly wrapped (and hence removed).